### PR TITLE
ci: seperatring GitHub workflow linting to own workflow

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -21,16 +21,6 @@ jobs:
       - name: Executing clean_git_history.
         run: RUST_LOG=trace clean_git_history --from-reference "origin/${{ github.base_ref }}"
 
-  github-actions-linting:
-    runs-on: ubuntu-latest
-    steps:
-    - name: Installing actionlint.
-      run: "GOBIN=/usr/local/bin/ go install github.com/rhysd/actionlint/cmd/actionlint@latest"
-    - name: Checkout code.
-      uses: actions/checkout@v3
-    - name: Running actionlint.
-      run: "actionlint .github/workflows/*"
-
   formatting:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/github-workflows.yml
+++ b/.github/workflows/github-workflows.yml
@@ -1,0 +1,15 @@
+name: GitHub Workflows
+
+on: pull_request
+
+jobs:
+
+  Linting:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Installing actionlint.
+      run: "GOBIN=/usr/local/bin/ go install github.com/rhysd/actionlint/cmd/actionlint@latest"
+    - name: Checkout code.
+      uses: actions/checkout@v3
+    - name: Running actionlint.
+      run: "actionlint .github/workflows/*"


### PR DESCRIPTION
Separating out the GitHub workflows linting to own workflow so any issues in the CI workflow does not cause the linting to be skipped.