### PR TITLE
build: cargo install --locked

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -20,7 +20,7 @@ rust-base:
 
 check-clean-git-history:
     FROM +rust-base
-    RUN cargo install clean_git_history --version 0.1.2
+    RUN cargo install clean_git_history --version 0.1.2 --locked
     DO +COPY_METADATA
     ARG from_reference="origin/HEAD"
     RUN ./ci/check-clean-git-history.sh --from-reference "${from_reference}"
@@ -28,7 +28,7 @@ check-clean-git-history:
 
 check-conventional-commits-linting:
     FROM +rust-base
-    RUN cargo install conventional_commits_linter --version 0.12.3
+    RUN cargo install conventional_commits_linter --version 0.12.3 --locked
     DO +COPY_METADATA
     ARG from_reference="origin/HEAD"
     RUN ./ci/check-conventional-commits-linting.sh --from-reference "${from_reference}"


### PR DESCRIPTION
* https://doc.rust-lang.org/cargo/commands/cargo-install.html

> By default, the Cargo.lock file that is included with the package will be ignored. This means that Cargo will recompute which versions of dependencies to use, possibly using newer versions that have been released since the package was published. The --locked flag can be used to force Cargo to use the packaged Cargo.lock file if it is available. This may be useful for ensuring reproducible builds, to use the exact same set of dependencies that were available when the package was published. It may also be useful if a newer version of a dependency is published that no longer builds on your system, or has other problems. The downside to using --locked is that you will not receive any fixes or updates to any dependency. Note that Cargo did not start publishing Cargo.lock files until version 1.37, which means packages published with prior versions will not have a Cargo.lock file available.